### PR TITLE
feat: mass-disable all neuropilot permission toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Shows a notification when it succeeds or fails.
 
 Reregisters all actions according to the permissions.
 
+### Disable all permissions
+
+Disable all permissions for Neuro immediately and reloads permissions. Also kills currently running tasks.
+Since it's intended to be a panic button, it is recommended to bind that command to a keyboard shortcut.
+
 ### Send File As Context
 
 Sends the entire current file as context to Neuro, along with the file name and configured language.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
 				"command": "neuropilot.reloadPermissions",
 				"title": "Reload Permissions",
 				"category": "NeuroPilot"
+			},
+			{
+				"command": "neuropilot.disableAllPermissions",
+				"title": "Disable All Permissions",
+				"category": "NeuroPilot"
 			}
 		],
 		"configuration": [

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,8 +1,7 @@
 import { NeuroClient } from 'neuro-game-sdk';
 import * as vscode from 'vscode';
-import { Range } from 'vscode';
 import { NEURO } from './constants';
-import { logOutput, assert, simpleFileName, filterFileContents, getPositionContext } from './utils';
+import { logOutput, assert, simpleFileName, getPositionContext } from './utils';
 
 let lastSuggestions: string[] = [];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,4 @@
 import * as vscode from 'vscode';
-import * as fs from "fs";
-import * as path from "path";
 
 import { NEURO } from './constants';
 import { logOutput, createClient, onClientConnected } from './utils';
@@ -68,18 +66,19 @@ function registerPostActionHandler() {
 
 function disableAllPermissions() {
     const config = vscode.workspace.getConfiguration('neuropilot');
-
-    const permissionKeys = config.get<{ [key: string]: boolean }>('permission')
-
+    const permissionKeys = config.get<{ [key: string]: boolean }>('permission');
     // Disable each permission one-by-one
+    let promises: Thenable<void>[] = [];
     if (permissionKeys) {
         for (const key of Object.keys(permissionKeys)) {
-            config.update(`permission.${key}`, false, vscode.ConfigurationTarget.Workspace);
+            promises.push(config.update(`permission.${key}`, false, vscode.ConfigurationTarget.Workspace));
         }
     }
+    Promise.all(promises).then(() => {
 
-    // Send context and reload
-    reloadPermissions();
-    NEURO.client?.sendContext("Vedal has turned off all dangerous permissions.");
-    vscode.window.showInformationMessage("All dangerous permissions have been turned off and actions have been re-registered.");
+        // Send context and reload
+        reloadPermissions();
+        NEURO.client?.sendContext("Vedal has turned off all dangerous permissions.");
+        vscode.window.showInformationMessage("All dangerous permissions have been turned off and actions have been re-registered.");
+    });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as fs from "fs";
+import * as path from "path";
 
 import { NEURO } from './constants';
 import { logOutput, createClient, onClientConnected } from './utils';
@@ -25,6 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('neuropilot.sendCurrentFile', sendCurrentFile);
     vscode.commands.registerCommand('neuropilot.giveCookie', giveCookie);
     vscode.commands.registerCommand('neuropilot.reloadPermissions', reloadPermissions);
+    vscode.commands.registerCommand('neuropilot.disableAllPermissions', disableAllPermissions);
 
     registerChatParticipant(context);
 
@@ -61,4 +64,22 @@ function registerPostActionHandler() {
         
         NEURO.client?.sendActionResult(actionData.id, true, 'Unknown action');
     });
+}
+
+function disableAllPermissions() {
+    const config = vscode.workspace.getConfiguration('neuropilot');
+
+    const permissionKeys = config.get<{ [key: string]: boolean }>('permission')
+
+    // Disable each permission one-by-one
+    if (permissionKeys) {
+        for (const key of Object.keys(permissionKeys)) {
+            config.update(`permission.${key}`, false, vscode.ConfigurationTarget.Workspace);
+        }
+    }
+
+    // Send context and reload
+    reloadPermissions();
+    NEURO.client?.sendContext("Vedal has turned off all dangerous permissions.");
+    vscode.window.showInformationMessage("All dangerous permissions have been turned off and actions have been re-registered.");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,12 @@ function disableAllPermissions() {
         }
     }
     Promise.all(promises).then(() => {
-
+        const exe = NEURO.currentTaskExecution;
+        if (exe) {
+            exe.terminate();
+            NEURO.currentTaskExecution = null;
+        }
+        // TO-DO: Terminate currently running terminal command.
         // Send context and reload
         reloadPermissions();
         NEURO.client?.sendContext("Vedal has turned off all dangerous permissions.");


### PR DESCRIPTION
self-explanatory, disables all permission toggles immediately in the workspace and reloads permissions to ensure they are applied immediately

finishes one task of the v1.5.0 PR