### PR TITLE
Improve editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,17 +73,30 @@
 					"neuropilot.beforeContext": {
 						"type": "integer",
 						"default": 10,
-						"description": "The number of lines before the cursor position to include in the completion request"
+						"description": "The number of lines before the cursor position to include as context when editing a file or sending a completion request"
 					},
 					"neuropilot.afterContext": {
 						"type": "integer",
 						"default": 10,
-						"description": "The number of lines after the cursor position to include in the completion request"
+						"description": "The number of lines after the cursor position to include as context when editing a file or sending a completion request"
 					},
 					"neuropilot.maxCompletions": {
 						"type": "integer",
 						"default": 3,
 						"description": "The maximum number of completions to request"
+					},
+					"neuropilot.firstLineNumber": {
+						"type": "integer",
+						"default": 1,
+						"description": "The line / column number format to use when sending context to Neuro, or when parsing actions sent by Neuro",
+						"enum": [
+							0,
+							1
+						],
+						"enumDescriptions": [
+							"Line and column numbers start at 0",
+							"Line and column numbers start at 1"
+						]
 					},
 					"neuropilot.completionTrigger": {
 						"type": "string",

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ class Config {
     get gameName(): string                  { return get('gameName')!; }
     get beforeContext(): number             { return get('beforeContext')!; }
     get afterContext(): number              { return get('afterContext')!; }
+    get firstLineNumber(): number           { return get('firstLineNumber')!; }
     get maxCompletions(): number            { return get('maxCompletions')!; }
     get completionTrigger(): string         { return get('completionTrigger')!; }
     get initialContext(): string            { return get('initialContext')!; }

--- a/src/editing.ts
+++ b/src/editing.ts
@@ -104,8 +104,8 @@ export function handlePlaceCursor(actionData: ActionData): ActionResult {
         return ACTION_RESULT_NO_ACCESS;
     if(line >= document.lineCount)
         return actionResultRetry(`Line is out of bounds, the last line of the document is ${document.lineCount - 1}.`);
-    if(character >= document.lineAt(line).text.length)
-        return actionResultRetry(`Character is out of bounds, the last character of line ${line} is ${document.lineAt(line).text.length - 1}.`);
+    if(character > document.lineAt(line).text.length)
+        return actionResultRetry(`Character is out of bounds, the last character of line ${line} is ${document.lineAt(line).text.length}.`);
 
     vscode.window.activeTextEditor!.selection = new vscode.Selection(line, character, line, character);
     const cursorContext = getPositionContext(document, new vscode.Position(line, character));

--- a/src/editing.ts
+++ b/src/editing.ts
@@ -17,7 +17,7 @@ export const editingFileHandlers: { [key: string]: (actionData: ActionData) => A
     'replace_text': handleReplaceText,
     'delete_text': handleDeleteText,
     'find_text': handleFindText,
-    // 'undo': handleUndo,
+    'undo': handleUndo,
 }
 
 export function registerEditingActions() {
@@ -90,10 +90,10 @@ export function registerEditingActions() {
                     required: ['text', 'match'],
                 }
             },
-            // {
-            //     name: 'undo',
-            //     description: 'Undo the last action in the active document',
-            // },
+            {
+                name: 'undo',
+                description: 'Undo the last action in the active document. If this doesn\'t work, tell Vedal to focus VS Code.',
+            },
         ]);
     }
 }

--- a/src/neuro_client_helper.ts
+++ b/src/neuro_client_helper.ts
@@ -82,6 +82,14 @@ export function actionResultMissingParameter(parameterName: string): ActionResul
     };
 }
 
+export function actionResultIncorrectType(parameterName: string, expectedType: string, actualType: string): ActionResult {
+    logOutput('WARNING', `Action failed: "${parameterName}" must be of type "${expectedType}", but got "${actualType}".`);
+    return {
+        success: false,
+        message: `Action failed: "${parameterName}" must be of type "${expectedType}", but got "${actualType}".`,
+    };
+}
+
 /**
  * Create an action result that tells Neuro that she doesn't have the required permission.
  * @param permission The permission Neuro doesn't have.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -235,6 +235,10 @@ export interface TerminalSession {
 
 export const delayAsync = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+export function escapeRegExp(string: string): string {
+    return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 export interface Permission {
     /** The ID of the permission in package.json, without the `neuropilot.permission.` prefix. */
     id: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,10 +93,14 @@ export function filterFileContents(contents: string): string {
     return contents.replace(/\r\n/g, '\n');
 }
 
-interface NeuroPositionContext {
+export interface NeuroPositionContext {
+    /** The context before the range. */
     contextBefore: string;
+    /** The context after the range. */
     contextAfter: string;
+    /** The zero-based line where {@link contextBefore} starts. */
     startLine: number;
+    /** The zero-based line where {@link contextAfter} ends. */
     endLine: number;
 }
 


### PR DESCRIPTION
## Changes

- Return context as a single code block, denote cursor position with `<<<|>>>`
  - ~~TODO: Test if Jippity can work with this syntax~~ Jippity doesn't work at the moment
- Return context for all editing actions
- Add an option to find / replace / delete with RegEx and replace with RegEx substitution
  - Supports both JS and .NET substitution syntax (except `$'` and `` $` `` because those would basically duplicate the file multiple times)
- Add an option to find / replace / delete first in file, last in file, first after cursor, last before cursor, all in file.