### PR TITLE
chore(global): Requested Command Execution (RCE) framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ Note that this only returns diagnostics of files that are loaded in the current 
 
 This extension uses the [TypeScript/JavaScript SDK](https://github.com/AriesAlex/typescript-neuro-game-sdk) by [AriesAlex](https://github.com/AriesAlex).
 
+### "Why is there a file named rce.ts in it??? Is there an intentional RCE inside this extension???" <!-- had to add this just in case -->
+
+The framework developed for forcing Neuro to request to run actions instead of just directly allowing her to do that action is called the Requested Command Execution (or Request for Command Execution) framework when it was first conceived. The short answer is no, there isn't an intentional Remote Code Execution vulnerability in this extension, but by enabling Neuro's access to Pseudoterminals, one could say she already has access to a very powerful RCE, so be careful with that one.
+
 ## Debugging
 
 - Clone the repository

--- a/src/rce.ts
+++ b/src/rce.ts
@@ -1,0 +1,46 @@
+/**
+ * rce stands for Requested Command Execution
+ * (or Request for Command Execution if you don't mind the omitted 'f')
+ * definitely didn't choose the acronym for its resemblance to a software vulnerability
+ */
+
+import * as vscode from 'vscode';
+import { ActionData, ActionResult, actionResultNoPermission, actionResultAccept } from './neuro_client_helper';
+import { PERMISSIONS } from './config';
+
+/**
+ * A prompt parameter can either be a string or a function that converts ActionData into a prompt string.
+ */
+export type PromptGenerator = string | ((actionData: ActionData) => string);
+
+/**
+ * Wraps an action handler with a confirmation prompt.
+ * When the user confirms (via a modal dialog), this function immediately returns a success result (e.g. "Requested to run command.")
+ * and then runs the original handler asynchronously.
+ *
+ * @param handler The action handler to wrap.
+ * @param prompt A custom prompt message or generator function (optional).
+ * @param earlyMessage The message to immediately return as a success result.
+ * @returns A new handler that first asks for confirmation, then returns early before running the handler.
+ */
+export function wrapWithConfirmation(
+    handler: (actionData: ActionData) => ActionResult,
+    prompt?: PromptGenerator,
+    earlyMessage: string = "Requested to run command."
+): (actionData: ActionData) => Promise<ActionResult> {
+    return async (actionData: ActionData): Promise<ActionResult> => {
+        const message: string = typeof prompt === 'function'
+            ? prompt(actionData)
+            : prompt ?? `Neuro requested to run the action "${actionData.name}". Do you want to proceed?`;
+        const confirmation = await vscode.window.showWarningMessage(message, { modal: true }, "Allow");
+        if (confirmation !== "Allow") {
+            return actionResultNoPermission(PERMISSIONS.terminalAccess);
+        }
+        // Execute the original handler asynchronously.
+        setTimeout(() => {
+            handler(actionData);
+        }, 0);
+        // Immediately return a success result with the early message.
+        return actionResultAccept(earlyMessage);
+    };
+}


### PR DESCRIPTION
# ⚠️This PR is a WIP, and will probably also go through multiple iterations ⚠️
Closes #23 | #20, #21, #22, #25 partially depend on this | #8 depends on this

So during the recent set of "shredding protections and giving Neuro more power on autopilot mode" PRs, mintcandy (on the Neurocord thread) proposed adding a request system to the pseudoterminal set of actions, where Neuro could only request to run stuff, never run it directly.

This PR aims to add an extension-wide system for this to allow for other commands to be ran by a notification first. This allows for requiring requests to run actions that can be considered dangerous for one reason or another, not just pseudoterminal. This also allows them to be knocked down from Autopilot mode actions to Copilot mode actions.

## Why did I name it the RCE framework?

Initially because it was just a funny coincidence, but I realised that there was a deeper meaning:
- RCE in normal terms means Remote Code Execution, which this PR implements a framework to try and prevent for this extension.
- The name reflects Neuro's potential power if she uses this extension.
- By itself, this extension is already an RCE(bad) minefield, what with connecting a WebSocket server to interact with Visual Studio Code. Autopilot settings (namely Run Tasks and Edit Active Document) is already theoretically an RCE(bad) because most languages have a way to execute stuff in a separate shell. Examples: `os.system` on Python, `exec` on Node.js

## Final notes

I made it so that we didn't have to backadd a lot of stuff into each and every individual handler, but that might end up not mattering anyways depending on design iterations.